### PR TITLE
Add Eloquent models for waste management tables

### DIFF
--- a/app/Models/DafAkses.php
+++ b/app/Models/DafAkses.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DafAkses extends Model
+{
+    use HasFactory;
+
+    protected $table = 'daf_akses';
+    protected $primaryKey = 'akses_id';
+    public $timestamps = false;
+    protected $fillable = ['nama', 'jenis_akses'];
+
+    public function userAkses()
+    {
+        return $this->hasMany(UserAkses::class, 'akses_id');
+    }
+}

--- a/app/Models/DafSatuan.php
+++ b/app/Models/DafSatuan.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DafSatuan extends Model
+{
+    use HasFactory;
+
+    protected $table = 'daf_satuan';
+    protected $primaryKey = 'satuan_id';
+    public $timestamps = false;
+    protected $fillable = ['nama'];
+
+    public function kontaminasi()
+    {
+        return $this->hasMany(LapFormKontaminasi::class, 'sat_berat_id');
+    }
+}

--- a/app/Models/DafSifat.php
+++ b/app/Models/DafSifat.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DafSifat extends Model
+{
+    use HasFactory;
+
+    protected $table = 'daf_sifat';
+    protected $primaryKey = 'sifat_id';
+    public $timestamps = false;
+    protected $fillable = ['nama'];
+}

--- a/app/Models/DafWadah.php
+++ b/app/Models/DafWadah.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DafWadah extends Model
+{
+    use HasFactory;
+
+    protected $table = 'daf_wadah';
+    protected $primaryKey = 'wadah_id';
+    public $timestamps = false;
+    protected $fillable = ['nama'];
+}

--- a/app/Models/Fasilitas.php
+++ b/app/Models/Fasilitas.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Fasilitas extends Model
+{
+    use HasFactory;
+
+    protected $table = 'fasilitas';
+    protected $primaryKey = 'fas_id';
+    public $timestamps = false;
+    protected $fillable = ['nama'];
+
+    public function laporan()
+    {
+        return $this->hasMany(Laporan::class, 'fas_id');
+    }
+}

--- a/app/Models/JenisLaporan.php
+++ b/app/Models/JenisLaporan.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JenisLaporan extends Model
+{
+    use HasFactory;
+
+    protected $table = 'jenis_laporan';
+    protected $primaryKey = 'jenis_lap_id';
+    public $timestamps = false;
+    protected $fillable = ['nama', 'jenis_tindakan'];
+
+    public function laporan()
+    {
+        return $this->hasMany(Laporan::class, 'jenis_lap_id');
+    }
+}

--- a/app/Models/JenisLimbah.php
+++ b/app/Models/JenisLimbah.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JenisLimbah extends Model
+{
+    use HasFactory;
+
+    protected $table = 'jenis_limbah';
+    protected $primaryKey = 'jenis_limbah_id';
+    public $timestamps = false;
+    protected $fillable = ['nama', 'uraian'];
+
+    public function laporan()
+    {
+        return $this->hasMany(Laporan::class, 'jenis_limbah_id');
+    }
+}

--- a/app/Models/KatSumber.php
+++ b/app/Models/KatSumber.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class KatSumber extends Model
+{
+    use HasFactory;
+
+    protected $table = 'kat_sumber';
+    protected $primaryKey = 'kat_sumber_id';
+    public $timestamps = false;
+    protected $fillable = ['nama'];
+
+    public function zraTerbuka()
+    {
+        return $this->hasMany(LapFormZraTerbuka::class, 'kat_sumber_id');
+    }
+
+    public function zraTertutup()
+    {
+        return $this->hasMany(LapFormZraTertutup::class, 'kat_sumber_id');
+    }
+}

--- a/app/Models/LapFormBrbn.php
+++ b/app/Models/LapFormBrbn.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LapFormBrbn extends Model
+{
+    use HasFactory;
+
+    protected $table = 'lap_form_brbn';
+    protected $primaryKey = 'data_id';
+    public $timestamps = false;
+    protected $fillable = [
+        'lap_id', 'bn_id', 'tgl', 'berat', 'burn_up', 'lokasi_penyimpanan', 'ket'
+    ];
+
+    public function laporan()
+    {
+        return $this->belongsTo(Laporan::class, 'lap_id');
+    }
+
+    public function bahanNuklir()
+    {
+        return $this->belongsTo(MasterBahanNuklir::class, 'bn_id');
+    }
+}

--- a/app/Models/LapFormKontaminasi.php
+++ b/app/Models/LapFormKontaminasi.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LapFormKontaminasi extends Model
+{
+    use HasFactory;
+
+    protected $table = 'lap_form_kontaminasi';
+    protected $primaryKey = 'data_id';
+    public $timestamps = false;
+    protected $fillable = [
+        'lap_id', 'nama_barang', 'berat', 'sat_berat_id', 'sifat_id', 'wadah_id'
+    ];
+
+    public function laporan()
+    {
+        return $this->belongsTo(Laporan::class, 'lap_id');
+    }
+
+    public function satuan()
+    {
+        return $this->belongsTo(DafSatuan::class, 'sat_berat_id');
+    }
+
+    public function sifat()
+    {
+        return $this->belongsTo(DafSifat::class, 'sifat_id');
+    }
+
+    public function wadah()
+    {
+        return $this->belongsTo(DafWadah::class, 'wadah_id');
+    }
+}

--- a/app/Models/LapFormZraTerbuka.php
+++ b/app/Models/LapFormZraTerbuka.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LapFormZraTerbuka extends Model
+{
+    use HasFactory;
+
+    protected $table = 'lap_form_zra_terbuka';
+    protected $primaryKey = 'data_id';
+    public $timestamps = false;
+    protected $fillable = [
+        'lap_id', 'master_sumber_id', 'tipe', 'no_seri',
+        'jumlah', 'satuan_id', 'sifat_id', 'kat_sumber_id'
+    ];
+
+    public function laporan()
+    {
+        return $this->belongsTo(Laporan::class, 'lap_id');
+    }
+
+    public function masterSumber()
+    {
+        return $this->belongsTo(MasterSumber::class, 'master_sumber_id');
+    }
+
+    public function satuan()
+    {
+        return $this->belongsTo(DafSatuan::class, 'satuan_id');
+    }
+
+    public function sifat()
+    {
+        return $this->belongsTo(DafSifat::class, 'sifat_id');
+    }
+
+    public function kategori()
+    {
+        return $this->belongsTo(KatSumber::class, 'kat_sumber_id');
+    }
+}

--- a/app/Models/LapFormZraTertutup.php
+++ b/app/Models/LapFormZraTertutup.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LapFormZraTertutup extends Model
+{
+    use HasFactory;
+
+    protected $table = 'lap_form_zra_tertutup';
+    protected $primaryKey = 'data_id';
+    public $timestamps = false;
+    protected $fillable = [
+        'lap_id', 'master_sumber_id', 'tipe', 'no_seri',
+        'jumlah', 'sat_jumlah_id', 'sifat_id', 'kat_sumber_id'
+    ];
+
+    public function laporan()
+    {
+        return $this->belongsTo(Laporan::class, 'lap_id');
+    }
+
+    public function masterSumber()
+    {
+        return $this->belongsTo(MasterSumber::class, 'master_sumber_id');
+    }
+
+    public function satuan()
+    {
+        return $this->belongsTo(DafSatuan::class, 'sat_jumlah_id');
+    }
+
+    public function sifat()
+    {
+        return $this->belongsTo(DafSifat::class, 'sifat_id');
+    }
+
+    public function kategori()
+    {
+        return $this->belongsTo(KatSumber::class, 'kat_sumber_id');
+    }
+}

--- a/app/Models/Laporan.php
+++ b/app/Models/Laporan.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Laporan extends Model
+{
+    use HasFactory;
+
+    protected $table = 'laporan';
+    protected $primaryKey = 'lap_id';
+    public $timestamps = false;
+    protected $fillable = [
+        'fas_id', 'per_awal', 'per_akhir', 'jenis_lap_id', 'jenis_limbah_id'
+    ];
+
+    public function fasilitas()
+    {
+        return $this->belongsTo(Fasilitas::class, 'fas_id');
+    }
+
+    public function jenisLaporan()
+    {
+        return $this->belongsTo(JenisLaporan::class, 'jenis_lap_id');
+    }
+
+    public function jenisLimbah()
+    {
+        return $this->belongsTo(JenisLimbah::class, 'jenis_limbah_id');
+    }
+
+    public function brbn()
+    {
+        return $this->hasMany(LapFormBrbn::class, 'lap_id');
+    }
+
+    public function kontaminasi()
+    {
+        return $this->hasMany(LapFormKontaminasi::class, 'lap_id');
+    }
+
+    public function zraTerbuka()
+    {
+        return $this->hasMany(LapFormZraTerbuka::class, 'lap_id');
+    }
+
+    public function zraTertutup()
+    {
+        return $this->hasMany(LapFormZraTertutup::class, 'lap_id');
+    }
+}

--- a/app/Models/MasterBahanNuklir.php
+++ b/app/Models/MasterBahanNuklir.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MasterBahanNuklir extends Model
+{
+    use HasFactory;
+
+    protected $table = 'master_bahan_nuklir';
+    protected $primaryKey = 'bn_id';
+    public $timestamps = false;
+    protected $fillable = ['batch_id', 'tag_id'];
+
+    public function brbn()
+    {
+        return $this->hasMany(LapFormBrbn::class, 'bn_id');
+    }
+}

--- a/app/Models/MasterSumber.php
+++ b/app/Models/MasterSumber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MasterSumber extends Model
+{
+    use HasFactory;
+
+    protected $table = 'master_sumber';
+    protected $primaryKey = 'master_sumber_id';
+    public $timestamps = false;
+    protected $fillable = [
+        'nama', 'tipe', 'no_seri', 'jumlah', 'sat_jumlah_id', 'sifat_id'
+    ];
+
+    public function satuan()
+    {
+        return $this->belongsTo(DafSatuan::class, 'sat_jumlah_id');
+    }
+
+    public function sifat()
+    {
+        return $this->belongsTo(DafSifat::class, 'sifat_id');
+    }
+
+    public function zraTerbuka()
+    {
+        return $this->hasMany(LapFormZraTerbuka::class, 'master_sumber_id');
+    }
+
+    public function zraTertutup()
+    {
+        return $this->hasMany(LapFormZraTertutup::class, 'master_sumber_id');
+    }
+}

--- a/app/Models/UserAkses.php
+++ b/app/Models/UserAkses.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserAkses extends Model
+{
+    use HasFactory;
+
+    protected $table = 'user_akses';
+    protected $primaryKey = 'user_akses_id';
+    public $timestamps = false;
+    protected $fillable = ['user_id', 'akses_id'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function akses()
+    {
+        return $this->belongsTo(DafAkses::class, 'akses_id');
+    }
+}


### PR DESCRIPTION
## Summary
- add Eloquent models for reference data and reporting tables

## Testing
- `composer install` *(fails: requires GitHub token)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c01e737dc83298dc92d735d30c671