### PR TITLE
Add DafAkses CRUD API

### DIFF
--- a/app/Http/Controllers/Api/DafAksesController.php
+++ b/app/Http/Controllers/Api/DafAksesController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\DafAkses;
+use Illuminate\Http\Request;
+
+class DafAksesController extends Controller
+{
+    public function index()
+    {
+        return response()->json(DafAkses::all());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nama' => 'required|string',
+            'jenis_akses' => 'required|string',
+        ]);
+
+        $dafakses = DafAkses::create($data);
+
+        return response()->json($dafakses, 201);
+    }
+
+    public function show(DafAkses $dafakses)
+    {
+        return response()->json($dafakses);
+    }
+
+    public function update(Request $request, DafAkses $dafakses)
+    {
+        $data = $request->validate([
+            'nama' => 'sometimes|required|string',
+            'jenis_akses' => 'sometimes|required|string',
+        ]);
+
+        $dafakses->update($data);
+
+        return response()->json($dafakses);
+    }
+
+    public function destroy(DafAkses $dafakses)
+    {
+        $dafakses->delete();
+
+        return response()->json(null, 204);
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,17 +1,19 @@
 <?php
 
-use App\Http\Controllers\Auth\RegisterController;
+use App\Http\Controllers\Api\DafAksesController;
 use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Auth\RegisterController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-
-
-
-// 
 Route::post('register', RegisterController::class);
 Route::post('login', LoginController::class);
+
+Route::apiResource('dafakses', DafAksesController::class)->parameters([
+    'dafakses' => 'dafakses'
+]);
 
 Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
+


### PR DESCRIPTION
## Summary
- implement DafAksesController with CRUD methods and validation
- register DafAkses API resource routes

## Testing
- `composer install` *(fails: Token (hidden): No token given, aborting)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c07e6b9588329a0ab75641ca6d8ca