### PR TITLE
Protect dafakses routes with Sanctum

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -11,7 +11,7 @@ Route::post('login', LoginController::class);
 
 Route::apiResource('dafakses', DafAksesController::class)->parameters([
     'dafakses' => 'dafakses'
-]);
+])->middleware('auth:sanctum');
 
 Route::get('/user', function (Request $request) {
     return $request->user();

--- a/tests/Feature/DafAksesAuthTest.php
+++ b/tests/Feature/DafAksesAuthTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class DafAksesAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('daf_akses', function (Blueprint $table) {
+            $table->increments('akses_id');
+            $table->string('nama');
+            $table->string('jenis_akses');
+        });
+    }
+
+    public function test_guest_cannot_access_dafakses()
+    {
+        $response = $this->getJson('/api/dafakses');
+        $response->assertStatus(401);
+    }
+
+    public function test_authenticated_user_can_access_dafakses()
+    {
+        $user = new User();
+        $user->id = 1;
+        $user->username = 'testuser';
+        $user->password_hash = bcrypt('password');
+        $user->status = 10;
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/dafakses');
+        $response->assertStatus(200);
+    }
+}
+


### PR DESCRIPTION
## Summary
- secure `dafakses` API resource with `auth:sanctum`
- add feature tests covering authenticated and guest access to `dafakses`

## Testing
- `php artisan route:list` *(fails: Failed opening required 'vendor/autoload.php')*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689c0ba919648329a4d9191e3b6f0adc