### PR TITLE
feat: add user crud api

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -3,12 +3,64 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 
 class UserController extends Controller
 {
-     public function index()
+    public function index()
     {
-        return response()->json(['users' => ['Alice', 'Bob']]);
+        return response()->json(User::all());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'username' => 'required|string',
+            'email' => 'sometimes|email',
+            'password' => 'required|string',
+            'status' => 'sometimes|integer',
+        ]);
+
+        $data['password_hash'] = Hash::make($data['password']);
+        unset($data['password']);
+        $data['status'] = $data['status'] ?? 10;
+
+        $user = User::create($data);
+
+        return response()->json($user, 201);
+    }
+
+    public function show(User $user)
+    {
+        return response()->json($user);
+    }
+
+    public function update(Request $request, User $user)
+    {
+        $data = $request->validate([
+            'username' => 'sometimes|string',
+            'email' => 'sometimes|email',
+            'password' => 'sometimes|string',
+            'status' => 'sometimes|integer',
+        ]);
+
+        if (isset($data['password'])) {
+            $data['password_hash'] = Hash::make($data['password']);
+            unset($data['password']);
+        }
+
+        $user->update($data);
+
+        return response()->json($user);
+    }
+
+    public function destroy(User $user)
+    {
+        $user->delete();
+
+        return response()->json(null, 204);
     }
 }
+

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,7 @@ class User extends Authenticatable
 
     protected $fillable = [
         'username',
+        'email',
         'password_hash',
         'status',
     ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\DafAksesController;
+use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\RegisterController;
 use Illuminate\Http\Request;
@@ -11,6 +12,10 @@ Route::post('login', LoginController::class);
 
 Route::apiResource('dafakses', DafAksesController::class)->parameters([
     'dafakses' => 'dafakses'
+])->middleware('auth:sanctum');
+
+Route::apiResource('users', UserController::class)->parameters([
+    'users' => 'user'
 ])->middleware('auth:sanctum');
 
 Route::get('/user', function (Request $request) {


### PR DESCRIPTION
## Summary
- add CRUD endpoints for User model
- enable email field on User model
- expose users API routes protected by sanctum

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: failed to open required '/workspace/api-waste/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_689c37c5e84483298fdd93179f11b487