### PR TITLE
Add DafSatuan CRUD API

### DIFF
--- a/app/Http/Controllers/Api/DafSatuanController.php
+++ b/app/Http/Controllers/Api/DafSatuanController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\DafSatuan;
+use Illuminate\Http\Request;
+
+class DafSatuanController extends Controller
+{
+    public function index()
+    {
+        return response()->json(DafSatuan::all());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nama' => 'required|string',
+        ]);
+
+        $dafsatuan = DafSatuan::create($data);
+
+        return response()->json($dafsatuan, 201);
+    }
+
+    public function show(DafSatuan $dafsatuan)
+    {
+        return response()->json($dafsatuan);
+    }
+
+    public function update(Request $request, DafSatuan $dafsatuan)
+    {
+        $data = $request->validate([
+            'nama' => 'sometimes|required|string',
+        ]);
+
+        $dafsatuan->update($data);
+
+        return response()->json($dafsatuan);
+    }
+
+    public function destroy(DafSatuan $dafsatuan)
+    {
+        $dafsatuan->delete();
+
+        return response()->json(null, 204);
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\DafAksesController;
+use App\Http\Controllers\Api\DafSatuanController;
 use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\RegisterController;
@@ -12,6 +13,10 @@ Route::post('login', LoginController::class);
 
 Route::apiResource('dafakses', DafAksesController::class)->parameters([
     'dafakses' => 'dafakses'
+])->middleware('auth:sanctum');
+
+Route::apiResource('dafsatuan', DafSatuanController::class)->parameters([
+    'dafsatuan' => 'dafsatuan'
 ])->middleware('auth:sanctum');
 
 Route::apiResource('users', UserController::class)->parameters([

--- a/tests/Feature/DafSatuanAuthTest.php
+++ b/tests/Feature/DafSatuanAuthTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class DafSatuanAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('daf_satuan', function (Blueprint $table) {
+            $table->increments('satuan_id');
+            $table->string('nama');
+        });
+    }
+
+    public function test_guest_cannot_access_dafsatuan()
+    {
+        $response = $this->getJson('/api/dafsatuan');
+        $response->assertStatus(401);
+    }
+
+    public function test_authenticated_user_can_access_dafsatuan()
+    {
+        $user = new User();
+        $user->id = 1;
+        $user->username = 'testuser';
+        $user->password_hash = bcrypt('password');
+        $user->status = 10;
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/dafsatuan');
+        $response->assertStatus(200);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add controller and routes to expose DafSatuan CRUD endpoints
- cover DafSatuan authentication access in tests

## Testing
- `php artisan test` *(fails: require(/workspace/api-waste/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: Failed to download symfony/polyfill-php80: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689c3e4e6e1c8329a000149808ee91af