### PR TITLE
Add CRUD API for DafSifat resource

### DIFF
--- a/app/Http/Controllers/Api/DafSifatController.php
+++ b/app/Http/Controllers/Api/DafSifatController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\DafSifat;
+use Illuminate\Http\Request;
+
+class DafSifatController extends Controller
+{
+    public function index()
+    {
+        return response()->json(DafSifat::all());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nama' => 'required|string',
+        ]);
+
+        $dafsifat = DafSifat::create($data);
+
+        return response()->json($dafsifat, 201);
+    }
+
+    public function show(DafSifat $dafsifat)
+    {
+        return response()->json($dafsifat);
+    }
+
+    public function update(Request $request, DafSifat $dafsifat)
+    {
+        $data = $request->validate([
+            'nama' => 'sometimes|required|string',
+        ]);
+
+        $dafsifat->update($data);
+
+        return response()->json($dafsifat);
+    }
+
+    public function destroy(DafSifat $dafsifat)
+    {
+        $dafsifat->delete();
+
+        return response()->json(null, 204);
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\DafAksesController;
+use App\Http\Controllers\Api\DafSifatController;
 use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\RegisterController;
@@ -12,6 +13,10 @@ Route::post('login', LoginController::class);
 
 Route::apiResource('dafakses', DafAksesController::class)->parameters([
     'dafakses' => 'dafakses'
+])->middleware('auth:sanctum');
+
+Route::apiResource('dafsifat', DafSifatController::class)->parameters([
+    'dafsifat' => 'dafsifat'
 ])->middleware('auth:sanctum');
 
 Route::apiResource('users', UserController::class)->parameters([

--- a/tests/Feature/DafSifatAuthTest.php
+++ b/tests/Feature/DafSifatAuthTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class DafSifatAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('daf_sifat', function (Blueprint $table) {
+            $table->increments('sifat_id');
+            $table->string('nama');
+        });
+    }
+
+    public function test_guest_cannot_access_dafsifat()
+    {
+        $response = $this->getJson('/api/dafsifat');
+        $response->assertStatus(401);
+    }
+
+    public function test_authenticated_user_can_access_dafsifat()
+    {
+        $user = new User();
+        $user->id = 1;
+        $user->username = 'testuser';
+        $user->password_hash = bcrypt('password');
+        $user->status = 10;
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/dafsifat');
+        $response->assertStatus(200);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add DafSifatController with CRUD endpoints
- register DafSifat routes
- cover DafSifat auth in feature tests

## Testing
- `composer install` (fails: CONNECT tunnel failed, response 403)
- `./vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689c43c0562c8329b1d685848b593182