### PR TITLE
Add DafWadah CRUD API

### DIFF
--- a/app/Http/Controllers/Api/DafWadahController.php
+++ b/app/Http/Controllers/Api/DafWadahController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\DafWadah;
+use Illuminate\Http\Request;
+
+class DafWadahController extends Controller
+{
+    public function index()
+    {
+        return response()->json(DafWadah::all());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nama' => 'required|string',
+        ]);
+
+        $dafwadah = DafWadah::create($data);
+
+        return response()->json($dafwadah, 201);
+    }
+
+    public function show(DafWadah $dafwadah)
+    {
+        return response()->json($dafwadah);
+    }
+
+    public function update(Request $request, DafWadah $dafwadah)
+    {
+        $data = $request->validate([
+            'nama' => 'sometimes|required|string',
+        ]);
+
+        $dafwadah->update($data);
+
+        return response()->json($dafwadah);
+    }
+
+    public function destroy(DafWadah $dafwadah)
+    {
+        $dafwadah->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\DafAksesController;
+use App\Http\Controllers\Api\DafWadahController;
 use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\RegisterController;
@@ -12,6 +13,10 @@ Route::post('login', LoginController::class);
 
 Route::apiResource('dafakses', DafAksesController::class)->parameters([
     'dafakses' => 'dafakses'
+])->middleware('auth:sanctum');
+
+Route::apiResource('dafwadah', DafWadahController::class)->parameters([
+    'dafwadah' => 'dafwadah'
 ])->middleware('auth:sanctum');
 
 Route::apiResource('users', UserController::class)->parameters([

--- a/tests/Feature/DafWadahAuthTest.php
+++ b/tests/Feature/DafWadahAuthTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class DafWadahAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('daf_wadah', function (Blueprint $table) {
+            $table->increments('wadah_id');
+            $table->string('nama');
+        });
+    }
+
+    public function test_guest_cannot_access_dafwadah()
+    {
+        $response = $this->getJson('/api/dafwadah');
+        $response->assertStatus(401);
+    }
+
+    public function test_authenticated_user_can_access_dafwadah()
+    {
+        $user = new User();
+        $user->id = 1;
+        $user->username = 'testuser';
+        $user->password_hash = bcrypt('password');
+        $user->status = 10;
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/dafwadah');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add DafWadahController with full CRUD endpoints
- expose dafwadah resource routes guarded by Sanctum
- test authentication for DafWadah API

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/api-waste/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689c472ca3b483299d9c4a1d9c746132